### PR TITLE
Removing 24h requirement to show leading zero

### DIFF
--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -14,7 +14,7 @@
 	<string id="pdndm0">Off</string>
 	<string id="pdndm1">No seconds</string>
 
-	<string id="leadingZeroSettings">Show Hours Leading Zero (24h mode)</string>
+	<string id="leadingZeroSettings">Show Hours Leading Zero</string>
 
 	<string id="secModeSettings">Seconds on power saving mode</string>
 	<string id="sm0">--</string>

--- a/source/drawable/TimeDrawable.mc
+++ b/source/drawable/TimeDrawable.mc
@@ -152,7 +152,7 @@ class TimeDrawable extends WatchUi.Drawable {
 		var clockTime = System.getClockTime();
 		var hour_ = clockTime.hour;
 		hour = Lang.format("$1$", [calculateHour(hour_)]);
-		if (leadingZero and hour.length() == 1 and timeFormat == 0) {
+		if (leadingZero and hour.length() == 1) {
 			hour = "0" + hour;
 		} 
 		minute = Lang.format("$1$", [ clockTime.min.format("%02d")]);


### PR DESCRIPTION
Please review if it is ok to remove the 24hour time format requirement for having a leading zero in hour value. Please let me know if you see any issues with this. 